### PR TITLE
Fix to avoid space_left underflow

### DIFF
--- a/src/netinet/sctp_output.c
+++ b/src/netinet/sctp_output.c
@@ -8267,7 +8267,11 @@ sctp_fill_outqueue(struct sctp_tcb *stcb,
 		}
 		strq = stcb->asoc.ss_functions.sctp_ss_select_stream(stcb, net, asoc);
 		total_moved += moved;
-		space_left -= moved;
+		if (space_left >= moved) {
+			space_left -= moved;
+		} else {
+			space_left = 0;
+		}
 		if (space_left >= SCTP_DATA_CHUNK_OVERHEAD(stcb)) {
 			space_left -= SCTP_DATA_CHUNK_OVERHEAD(stcb);
 		} else {


### PR DESCRIPTION
src/netinet/sctp_output.c 
In function sctp_fill_outqueue the variable space_left is decremented by the variable moved without a check for an underflow. This pull request adds the check.