### PR TITLE
feature/maxchunks unlimited

### DIFF
--- a/src/netinet/sctp_indata.c
+++ b/src/netinet/sctp_indata.c
@@ -1872,8 +1872,9 @@ sctp_process_a_data_chunk(struct sctp_tcb *stcb, struct sctp_association *asoc,
 		}
 	}
 	/* now do the tests */
-	if (((asoc->cnt_on_all_streams +
-	      asoc->cnt_msg_on_sb) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)) ||
+	if (((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) > 0) &&
+	     ((asoc->cnt_on_all_streams +
+	       asoc->cnt_msg_on_sb) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) ||
 	    (((int)asoc->my_rwnd) <= 0)) {
 		/*
 		 * When we have NO room in the rwnd we check to make sure
@@ -1908,8 +1909,9 @@ sctp_process_a_data_chunk(struct sctp_tcb *stcb, struct sctp_association *asoc,
 				/* Nope not in the valid range dump it */
 			dump_packet:
 				sctp_set_rwnd(stcb, asoc);
-				if ((asoc->cnt_on_all_streams +
-				     asoc->cnt_msg_on_sb) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)) {
+				if ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) > 0) &&
+				    ((asoc->cnt_on_all_streams +
+				      asoc->cnt_msg_on_sb) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) {
 					SCTP_STAT_INCR(sctps_datadropchklmt);
 				} else {
 					SCTP_STAT_INCR(sctps_datadroprwnd);
@@ -4101,7 +4103,8 @@ sctp_express_handle_sack(struct sctp_tcb *stcb, uint32_t cumack,
 			if (inp->send_callback &&
 			    (((inp->send_sb_threshold > 0) &&
 			      (sb_free_now >= inp->send_sb_threshold) &&
-			      (stcb->asoc.chunks_on_out_queue <= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) ||
+			      ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) == 0) ||
+			       (stcb->asoc.chunks_on_out_queue <= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)))) ||
 			     (inp->send_sb_threshold == 0))) {
 				atomic_add_int(&stcb->asoc.refcnt, 1);
 				SCTP_TCB_UNLOCK(stcb);

--- a/src/netinet/sctp_input.c
+++ b/src/netinet/sctp_input.c
@@ -607,7 +607,8 @@ sctp_process_init_ack(struct mbuf *m, int iphlen, int offset,
 			if (inp->send_callback &&
 			    (((inp->send_sb_threshold > 0) &&
 			      (sb_free_now >= inp->send_sb_threshold) &&
-			      (stcb->asoc.chunks_on_out_queue <= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) ||
+			      ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) == 0) ||
+			       (stcb->asoc.chunks_on_out_queue <= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)))) ||
 			     (inp->send_sb_threshold == 0))) {
 				atomic_add_int(&stcb->asoc.refcnt, 1);
 				SCTP_TCB_UNLOCK(stcb);

--- a/src/netinet/sctp_output.c
+++ b/src/netinet/sctp_output.c
@@ -13951,7 +13951,8 @@ sctp_lower_sosend(struct socket *so,
 			amount = 1;
 		}
 		if ((SCTP_SB_LIMIT_SND(so) <  (amount + inqueue_bytes + stcb->asoc.sb_send_resv)) ||
-		    (stcb->asoc.chunks_on_out_queue >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) {
+		    ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) > 0) &&
+		     (stcb->asoc.chunks_on_out_queue >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)))) {
 			SCTP_LTRACE_ERR_RET(inp, stcb, net, SCTP_FROM_SCTP_OUTPUT, EWOULDBLOCK);
 			if (sndlen > (ssize_t)SCTP_SB_LIMIT_SND(so))
 				error = EMSGSIZE;
@@ -14187,12 +14188,14 @@ sctp_lower_sosend(struct socket *so,
 	if (((max_len <= local_add_more) &&
 	     ((ssize_t)SCTP_SB_LIMIT_SND(so) >= local_add_more)) ||
 	    (max_len == 0) ||
-	    ((stcb->asoc.chunks_on_out_queue+stcb->asoc.stream_queue_cnt) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) {
+	    ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) > 0) &&
+	     ((stcb->asoc.chunks_on_out_queue+stcb->asoc.stream_queue_cnt) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)))) {
 		/* No room right now ! */
 		SOCKBUF_LOCK(&so->so_snd);
 		inqueue_bytes = stcb->asoc.total_output_queue_size - (stcb->asoc.chunks_on_out_queue * SCTP_DATA_CHUNK_OVERHEAD(stcb));
 		while ((SCTP_SB_LIMIT_SND(so) < (inqueue_bytes + local_add_more)) ||
-		       ((stcb->asoc.stream_queue_cnt + stcb->asoc.chunks_on_out_queue) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue))) {
+		       ((SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue) > 0) &&
+		        ((stcb->asoc.stream_queue_cnt + stcb->asoc.chunks_on_out_queue) >= SCTP_BASE_SYSCTL(sctp_max_chunks_on_queue)))) {
 			SCTPDBG(SCTP_DEBUG_OUTPUT1,"pre_block limit:%u <(inq:%d + %zd) || (%d+%d > %d)\n",
 			        (unsigned int)SCTP_SB_LIMIT_SND(so),
 			        inqueue_bytes,


### PR DESCRIPTION
src/netinet/sctp_output.c
Modified the checks if the number of chunks in the queue hit the limit sctp_max_chunks_on_queue, such that sctp_max_chunks_on_queue=0 is interpreted as unlimited.